### PR TITLE
컨트롤러 단위 테스트 추가

### DIFF
--- a/src/test/java/edu/handong/csee/histudy/controller/AdminControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/AdminControllerTest.java
@@ -1,0 +1,202 @@
+package edu.handong.csee.histudy.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.dto.TeamDto;
+import edu.handong.csee.histudy.dto.TeamIdDto;
+import edu.handong.csee.histudy.dto.TeamReportDto;
+import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
+import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.TeamService;
+import edu.handong.csee.histudy.service.UserService;
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(AdminController.class)
+class AdminControllerTest {
+
+  private MockMvc mockMvc;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @MockBean private AuthenticationInterceptor authenticationInterceptor;
+
+  @MockBean private TeamService teamService;
+
+  @MockBean private UserService userService;
+
+  @MockBean private JwtService jwtService;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    when(authenticationInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(new AdminController(teamService, userService))
+            .setControllerAdvice(ExceptionController.class)
+            .addInterceptors(authenticationInterceptor)
+            .build();
+  }
+
+  @Test
+  void 관리자가_그룹활동조회시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    List<TeamDto> teams = List.of();
+    when(teamService.getTeams(anyString())).thenReturn(teams);
+
+    mockMvc
+        .perform(get("/api/admin/manageGroup").requestAttr("claims", claims))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void 관리자가_그룹삭제시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    TeamIdDto dto = mock(TeamIdDto.class);
+    when(teamService.deleteTeam(any(TeamIdDto.class), anyString())).thenReturn(1);
+
+    mockMvc
+        .perform(
+            delete("/api/admin/group")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isOk())
+        .andExpect(content().string("1"));
+  }
+
+  @Test
+  void 관리자가_그룹보고서조회시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    TeamReportDto reportDto = mock(TeamReportDto.class);
+    when(teamService.getTeamReports(anyLong(), anyString())).thenReturn(reportDto);
+
+    mockMvc
+        .perform(get("/api/admin/groupReport/1").requestAttr("claims", claims))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void 관리자가_신청유저목록조회시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    List<UserDto.UserInfo> users = List.of();
+    when(userService.getAppliedUsers()).thenReturn(users);
+
+    mockMvc
+        .perform(get("/api/admin/allUsers").requestAttr("claims", claims))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void 관리자가_그룹매칭실행시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    doNothing().when(teamService).matchTeam();
+
+    mockMvc
+        .perform(post("/api/admin/team-match").requestAttr("claims", claims))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  void 관리자가_미매칭유저조회시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    List<UserDto.UserInfo> users = List.of();
+    when(userService.getUnmatchedUsers()).thenReturn(users);
+
+    mockMvc
+        .perform(get("/api/admin/unmatched-users").requestAttr("claims", claims))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void 관리자가_유저지원폼삭제시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    doNothing().when(userService).deleteUserForm(anyString());
+
+    mockMvc
+        .perform(delete("/api/admin/form").requestAttr("claims", claims).param("sid", "22500101"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void 관리자가_유저정보수정시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    UserDto.UserEdit form = mock(UserDto.UserEdit.class);
+    doNothing().when(userService).editUser(any(UserDto.UserEdit.class));
+
+    mockMvc
+        .perform(
+            post("/api/admin/edit-user")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void 관리자가_미배정유저목록조회시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    List<UserDto.UserInfo> users = List.of();
+    when(userService.getAppliedWithoutGroup()).thenReturn(users);
+
+    mockMvc
+        .perform(get("/api/admin/users/unassigned").requestAttr("claims", claims))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void 일반유저가_관리자API접근시_실패() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("user@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+    mockMvc
+        .perform(get("/api/admin/manageGroup").requestAttr("claims", claims))
+        .andExpect(status().isForbidden());
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/controller/ApplyFormControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/ApplyFormControllerTest.java
@@ -1,0 +1,135 @@
+package edu.handong.csee.histudy.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.controller.form.ApplyForm;
+import edu.handong.csee.histudy.controller.form.ApplyFormV2;
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.dto.ApplyFormDto;
+import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
+import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.UserService;
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(ApplyFormController.class)
+class ApplyFormControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockBean
+    private AuthenticationInterceptor authenticationInterceptor;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(authenticationInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new ApplyFormController(userService))
+                .setControllerAdvice(ExceptionController.class)
+                .addInterceptors(authenticationInterceptor)
+                .build();
+    }
+
+    @Test
+    void 사용자가_스터디신청시_성공_V1() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        ApplyForm form = ApplyForm.builder()
+                .friendIds(List.of("22500101"))
+                .courseIds(List.of(1L))
+                .build();
+
+        ApplyFormDto result = mock(ApplyFormDto.class);
+        when(userService.apply(any(ApplyForm.class), anyString())).thenReturn(result);
+
+        mockMvc.perform(post("/api/forms")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 사용자가_스터디신청시_성공_V2() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        ApplyFormV2 form = ApplyFormV2.builder()
+                .friendIds(List.of(1L, 2L))
+                .courseIds(List.of(1L, 2L))
+                .build();
+
+        StudyApplicant applicant = mock(StudyApplicant.class);
+        when(applicant.getPartnerRequests()).thenReturn(List.of());
+        when(applicant.getPreferredCourses()).thenReturn(List.of());
+
+        when(userService.apply(anyList(), anyList(), anyString())).thenReturn(applicant);
+
+        mockMvc.perform(post("/api/v2/forms")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 권한없는사용자가_스터디신청시_실패_V1() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        ApplyForm form = ApplyForm.builder()
+                .friendIds(List.of())
+                .courseIds(List.of())
+                .build();
+
+        mockMvc.perform(post("/api/forms")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 권한없는사용자가_스터디신청시_실패_V2() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        ApplyFormV2 form = ApplyFormV2.builder()
+                .friendIds(List.of())
+                .courseIds(List.of())
+                .build();
+
+        mockMvc.perform(post("/api/v2/forms")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/controller/AuthControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/AuthControllerTest.java
@@ -1,0 +1,114 @@
+package edu.handong.csee.histudy.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.controller.form.TokenForm;
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.controller.ExceptionController;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.jwt.GrantType;
+import edu.handong.csee.histudy.jwt.JwtPair;
+import edu.handong.csee.histudy.jwt.JwtProperties;
+import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.UserService;
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest({AuthController.class, ExceptionController.class})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private JwtProperties jwtProperties;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 사용자가_로그인시_성공() throws Exception {
+        User user = mock(User.class);
+        when(user.getEmail()).thenReturn("user@test.com");
+        when(user.getName()).thenReturn("Test User");
+        when(user.getRole()).thenReturn(Role.USER);
+
+        JwtPair tokens = new JwtPair(List.of("access-token", "refresh-token"));
+
+        when(userService.getUser(any(Optional.class))).thenReturn(user);
+        when(jwtService.issueToken(anyString(), anyString(), any(Role.class))).thenReturn(tokens);
+
+        mockMvc.perform(get("/api/auth/login")
+                .param("sub", "user@test.com"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(jsonPath("$.isRegistered").value(true))
+                .andExpect(jsonPath("$.tokenType").value("Bearer "))
+                .andExpect(jsonPath("$.role").value("USER"));
+    }
+
+    @Test
+    void 사용자가_파라미터없이로그인시_성공() throws Exception {
+        User user = mock(User.class);
+        when(user.getEmail()).thenReturn("user@test.com");
+        when(user.getName()).thenReturn("Test User");
+        when(user.getRole()).thenReturn(Role.USER);
+
+        JwtPair tokens = new JwtPair(List.of("access-token", "refresh-token"));
+
+        when(userService.getUser(any(Optional.class))).thenReturn(user);
+        when(jwtService.issueToken(anyString(), anyString(), any(Role.class))).thenReturn(tokens);
+
+        mockMvc.perform(get("/api/auth/login"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(jsonPath("$.isRegistered").value(true));
+    }
+
+    @Test
+    void 사용자가_토큰재발급시_성공() throws Exception {
+        TokenForm tokenForm = new TokenForm("refresh_token", "refresh-token");
+
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+
+        when(jwtService.validate(anyString())).thenReturn(claims);
+        when(jwtService.issueToken(any(Claims.class), any(GrantType.class))).thenReturn("new-access-token");
+
+        mockMvc.perform(post("/api/auth/token")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(tokenForm)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer "))
+                .andExpect(jsonPath("$.grantType").value("ACCESS_TOKEN"))
+                .andExpect(jsonPath("$.token").value("new-access-token"));
+    }
+
+    @Test
+    void 사용자가_토큰없이재발급시_실패() throws Exception {
+        TokenForm tokenForm = new TokenForm("refresh_token", null);
+
+        mockMvc.perform(post("/api/auth/token")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(tokenForm)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/CourseControllerTest.java
@@ -1,0 +1,170 @@
+package edu.handong.csee.histudy.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.dto.CourseDto;
+import edu.handong.csee.histudy.dto.CourseIdDto;
+import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
+import edu.handong.csee.histudy.service.CourseService;
+import edu.handong.csee.histudy.service.JwtService;
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(CourseController.class)
+class CourseControllerTest {
+
+  private MockMvc mockMvc;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @MockBean private AuthenticationInterceptor authenticationInterceptor;
+
+  @MockBean private CourseService courseService;
+
+  @MockBean private JwtService jwtService;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    when(authenticationInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(new CourseController(courseService))
+            .setControllerAdvice(ExceptionController.class)
+            .addInterceptors(authenticationInterceptor)
+            .build();
+  }
+
+  @Test
+  void 관리자가_강의목록업로드시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    MockMultipartFile file =
+        new MockMultipartFile("file", "courses.csv", "text/csv", "course content".getBytes());
+
+    doNothing().when(courseService).readCourseCSV(any());
+
+    mockMvc
+        .perform(multipart("/api/courses").file(file).requestAttr("claims", claims))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  void 관리자가_빈파일업로드시_실패() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    MockMultipartFile file =
+        new MockMultipartFile("file", "courses.csv", "text/csv", "".getBytes());
+
+    mockMvc
+        .perform(multipart("/api/courses").file(file).requestAttr("claims", claims))
+        .andExpect(status().isNotAcceptable());
+  }
+
+  @Test
+  void 관리자가_강의삭제시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("admin@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    CourseIdDto dto = mock(CourseIdDto.class);
+    when(courseService.deleteCourse(any(CourseIdDto.class))).thenReturn(1);
+
+    mockMvc
+        .perform(
+            post("/api/courses/delete")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isOk())
+        .andExpect(content().string("1"));
+  }
+
+  @Test
+  void 사용자가_강의목록전체조회시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("user@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+    List<CourseDto.CourseInfo> courses = List.of();
+    when(courseService.getCurrentCourses()).thenReturn(courses);
+
+    mockMvc
+        .perform(get("/api/courses").requestAttr("claims", claims))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void 사용자가_강의목록검색시_성공() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("user@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+    List<CourseDto.CourseInfo> courses = List.of();
+    when(courseService.search(anyString())).thenReturn(courses);
+
+    mockMvc
+        .perform(get("/api/courses").requestAttr("claims", claims).param("search", "java"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void 권한없는사용자가_강의업로드시_실패() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("user@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+    MockMultipartFile file =
+        new MockMultipartFile("file", "courses.csv", "text/csv", "course content".getBytes());
+
+    mockMvc
+        .perform(multipart("/api/courses").file(file).requestAttr("claims", claims))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void 권한없는사용자가_강의삭제시_실패() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("user@test.com");
+    when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+    CourseIdDto dto = mock(CourseIdDto.class);
+
+    mockMvc
+        .perform(
+            post("/api/courses/delete")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void 권한없는사용자가_강의조회시_실패() throws Exception {
+    Claims claims = mock(Claims.class);
+    when(claims.getSubject()).thenReturn("guest@test.com");
+    when(claims.get("rol", String.class)).thenReturn("GUEST");
+
+    mockMvc
+        .perform(get("/api/courses").requestAttr("claims", claims))
+        .andExpect(status().isForbidden());
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/controller/PublicControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/PublicControllerTest.java
@@ -1,0 +1,44 @@
+package edu.handong.csee.histudy.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.handong.csee.histudy.dto.TeamRankDto;
+import edu.handong.csee.histudy.jwt.JwtProperties;
+import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.TeamService;
+import edu.handong.csee.histudy.controller.ExceptionController;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest({PublicController.class, ExceptionController.class})
+class PublicControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TeamService teamService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private JwtProperties jwtProperties;
+
+    @Test
+    void 공개그룹목록조회시_성공() throws Exception {
+        TeamRankDto teamRankDto = new TeamRankDto(List.of());
+        when(teamService.getAllTeams()).thenReturn(teamRankDto);
+
+        mockMvc.perform(get("/api/public/teams"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"));
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
@@ -1,0 +1,295 @@
+package edu.handong.csee.histudy.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.controller.form.ReportForm;
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.dto.CourseDto;
+import edu.handong.csee.histudy.dto.ReportDto;
+import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
+import edu.handong.csee.histudy.repository.AcademicTermRepository;
+import edu.handong.csee.histudy.repository.StudyGroupRepository;
+import edu.handong.csee.histudy.repository.UserRepository;
+import edu.handong.csee.histudy.service.CourseService;
+import edu.handong.csee.histudy.service.ImageService;
+import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.ReportService;
+import edu.handong.csee.histudy.service.TeamService;
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(TeamController.class)
+class TeamControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockBean
+    private AuthenticationInterceptor authenticationInterceptor;
+
+    @MockBean
+    private ReportService reportService;
+
+    @MockBean
+    private CourseService courseService;
+
+    @MockBean
+    private TeamService teamService;
+
+    @MockBean
+    private ImageService imageService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private AcademicTermRepository academicTermRepository;
+
+    @MockBean
+    private StudyGroupRepository studyGroupRepository;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(authenticationInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new TeamController(reportService, courseService, teamService, imageService, userRepository, academicTermRepository, studyGroupRepository))
+                .setControllerAdvice(ExceptionController.class)
+                .addInterceptors(authenticationInterceptor)
+                .build();
+    }
+
+    @Test
+    void 그룹원이_스터디보고서생성시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        ReportForm form = ReportForm.builder()
+                .courses(List.of(1L))
+                .content("Study content")
+                .totalMinutes(120L)
+                .images(List.of("/path/to/image.jpg"))
+                .build();
+
+        ReportDto.ReportInfo reportInfo = mock(ReportDto.ReportInfo.class);
+        when(reportService.createReport(any(ReportForm.class), anyString())).thenReturn(reportInfo);
+
+        mockMvc.perform(post("/api/team/reports")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 그룹원이_보고서목록조회시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        List<ReportDto.ReportInfo> reports = List.of();
+        when(reportService.getReports(anyString())).thenReturn(reports);
+
+        mockMvc.perform(get("/api/team/reports")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 그룹원이_특정보고서조회시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        ReportDto.ReportInfo reportInfo = mock(ReportDto.ReportInfo.class);
+        when(reportService.getReport(anyLong())).thenReturn(Optional.of(reportInfo));
+
+        mockMvc.perform(get("/api/team/reports/1")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 그룹원이_없는보고서조회시_실패() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        when(reportService.getReport(anyLong())).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/team/reports/1")
+                .requestAttr("claims", claims))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 그룹원이_보고서수정시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        ReportForm form = ReportForm.builder()
+                .courses(List.of(1L))
+                .content("Updated content")
+                .totalMinutes(150L)
+                .images(List.of("/path/to/updated_image.jpg"))
+                .build();
+
+        when(reportService.updateReport(anyLong(), any(ReportForm.class))).thenReturn(true);
+
+        mockMvc.perform(patch("/api/team/reports/1")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 그룹원이_없는보고서수정시_실패() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        ReportForm form = ReportForm.builder().build();
+        when(reportService.updateReport(anyLong(), any(ReportForm.class))).thenReturn(false);
+
+        mockMvc.perform(patch("/api/team/reports/1")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 그룹원이_보고서삭제시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        when(reportService.deleteReport(anyLong())).thenReturn(true);
+
+        mockMvc.perform(delete("/api/team/reports/1")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 그룹원이_없는보고서삭제시_실패() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        when(reportService.deleteReport(anyLong())).thenReturn(false);
+
+        mockMvc.perform(delete("/api/team/reports/1")
+                .requestAttr("claims", claims))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 그룹원이_선택강의목록조회시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        List<CourseDto.CourseInfo> courses = List.of();
+        when(courseService.getTeamCourses(anyString())).thenReturn(courses);
+
+        mockMvc.perform(get("/api/team/courses")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 그룹원이_팀원목록조회시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        List<UserDto.UserMeWithMasking> users = List.of();
+        when(teamService.getTeamUsers(anyString())).thenReturn(users);
+
+        mockMvc.perform(get("/api/team/users")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 그룹원이_보고서이미지업로드시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "test image content".getBytes());
+
+        String imagePath = "/path/to/image.jpg";
+        when(imageService.getImagePaths(anyString(), any(), any(Optional.class))).thenReturn(imagePath);
+
+        mockMvc.perform(multipart("/api/team/reports/image")
+                .file(image)
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.imagePath").value(imagePath));
+    }
+
+    @Test
+    void 그룹원이_특정보고서이미지업로드시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("member@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.MEMBER.name());
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "test image content".getBytes());
+
+        String imagePath = "/path/to/image.jpg";
+        when(imageService.getImagePaths(anyString(), any(), any(Optional.class))).thenReturn(imagePath);
+
+        mockMvc.perform(multipart("/api/team/reports/1/image")
+                .file(image)
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.imagePath").value(imagePath));
+    }
+
+    @Test
+    void 권한없는사용자가_보고서작성시_실패() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        ReportForm form = ReportForm.builder().build();
+
+        mockMvc.perform(post("/api/team/reports")
+                .requestAttr("claims", claims)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(form)))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/controller/UserControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/UserControllerTest.java
@@ -1,0 +1,223 @@
+package edu.handong.csee.histudy.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.controller.form.UserForm;
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.dto.ApplyFormDto;
+import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
+import edu.handong.csee.histudy.jwt.JwtPair;
+import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.UserService;
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockBean
+    private AuthenticationInterceptor authenticationInterceptor;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(authenticationInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new UserController(userService, jwtService))
+                .setControllerAdvice(ExceptionController.class)
+                .addInterceptors(authenticationInterceptor)
+                .build();
+    }
+
+    @Test
+    void 사용자가_회원가입시_성공() throws Exception {
+        UserForm userForm = new UserForm("google-sub-123", "Test User", "user@test.com", "22500101");
+        JwtPair tokens = new JwtPair(List.of("access-token", "refresh-token"));
+
+        doNothing().when(userService).signUp(any(UserForm.class));
+        when(jwtService.issueToken(anyString(), anyString(), any(Role.class))).thenReturn(tokens);
+
+        mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(userForm)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.isRegistered").value(true))
+                .andExpect(jsonPath("$.tokenType").value("Bearer "))
+                .andExpect(jsonPath("$.role").value("USER"));
+    }
+
+    @Test
+    void 사용자가_유저검색시_성공_V1() throws Exception {
+        String token = "Bearer access-token";
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+
+        User user = mock(User.class);
+        when(user.getEmail()).thenReturn("friend@test.com");
+        when(user.getRole()).thenReturn(Role.USER);
+        List<User> users = List.of(user);
+
+        when(jwtService.extractToken(any(Optional.class))).thenReturn("access-token");
+        when(jwtService.validate(anyString())).thenReturn(claims);
+        when(userService.search(any(Optional.class))).thenReturn(users);
+
+        mockMvc.perform(get("/api/users")
+                .param("search", "friend")
+                .header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 사용자가_유저검색시_성공_V2() throws Exception {
+        String token = "Bearer access-token";
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+
+        User user = mock(User.class);
+        when(user.getEmail()).thenReturn("friend@test.com");
+        when(user.getRole()).thenReturn(Role.USER);
+        List<User> users = List.of(user);
+
+        when(jwtService.extractToken(any(Optional.class))).thenReturn("access-token");
+        when(jwtService.validate(anyString())).thenReturn(claims);
+        when(userService.search(any(Optional.class))).thenReturn(users);
+
+        mockMvc.perform(get("/api/v2/users")
+                .param("search", "friend")
+                .header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 사용자가_내정보조회시_성공() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        UserDto.UserMe userMe = mock(UserDto.UserMe.class);
+        when(userService.getUserMe(any(Optional.class))).thenReturn(userMe);
+
+        mockMvc.perform(get("/api/users/me")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 사용자가_신청정보조회시_성공_V1() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        StudyApplicant applicant = mock(StudyApplicant.class);
+        when(applicant.getPartnerRequests()).thenReturn(List.of());
+        when(applicant.getPreferredCourses()).thenReturn(List.of());
+
+        when(userService.getUserInfo(anyString())).thenReturn(Optional.of(applicant));
+
+        mockMvc.perform(get("/api/users/me/forms")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 사용자가_없는신청정보조회시_실패_V1() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        when(userService.getUserInfo(anyString())).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/users/me/forms")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 사용자가_신청정보조회시_성공_V2() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        StudyApplicant applicant = mock(StudyApplicant.class);
+        when(applicant.getPartnerRequests()).thenReturn(List.of());
+        when(applicant.getPreferredCourses()).thenReturn(List.of());
+
+        when(userService.getUserInfo(anyString())).thenReturn(Optional.of(applicant));
+
+        mockMvc.perform(get("/api/v2/users/me/forms")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 사용자가_없는신청정보조회시_실패_V2() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn(Role.USER.name());
+
+        when(userService.getUserInfo(anyString())).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v2/users/me/forms")
+                .requestAttr("claims", claims))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+
+    @Test
+    void 권한없는사용자가_접근시_실패() throws Exception {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+        when(claims.get("rol", String.class)).thenReturn("GUEST");
+
+        mockMvc.perform(get("/api/users/me")
+                .requestAttr("claims", claims))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 사용자가_키워드없이유저검색시_성공() throws Exception {
+        String token = "Bearer access-token";
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("user@test.com");
+
+        when(jwtService.extractToken(any(Optional.class))).thenReturn("access-token");
+        when(jwtService.validate(anyString())).thenReturn(claims);
+        when(userService.search(any(Optional.class))).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/users")
+                .header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"));
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/repository/AcademicTermRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/AcademicTermRepositoryTest.java
@@ -1,0 +1,82 @@
+package edu.handong.csee.histudy.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.handong.csee.histudy.domain.AcademicTerm;
+import edu.handong.csee.histudy.domain.TermType;
+import edu.handong.csee.histudy.repository.jpa.JpaAcademicTermRepository;
+import edu.handong.csee.histudy.support.BaseRepositoryTest;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AcademicTermRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired private JpaAcademicTermRepository academicTermRepository;
+
+  @Test
+  void 현재학기조회시_현재학기반환() {
+    // When - 이미 BaseRepositoryTest에서 currentTerm이 생성됨
+    Optional<AcademicTerm> result = academicTermRepository.findCurrentSemester();
+
+    // Then
+    assertThat(result).isPresent();
+    assertAcademicTerm(result.get(), 2025, TermType.SPRING, true);
+  }
+
+  @Test
+  void 특정년도학기조회시_해당학기반환() {
+    // Given - 별도의 과거 학기 데이터 생성
+    AcademicTerm testTerm =
+        AcademicTerm.builder()
+            .academicYear(2020)
+            .semester(TermType.WINTER)
+            .isCurrent(false)
+            .build();
+    persistAndFlush(testTerm);
+
+    // When
+    Optional<AcademicTerm> result = academicTermRepository.findByYearAndTerm(2020, TermType.WINTER);
+
+    // Then - 해당 학기는 현재 학기가 아님
+    assertThat(result).isPresent();
+    assertAcademicTerm(result.get(), 2020, TermType.WINTER, false);
+  }
+
+  @Test
+  void 년도와학기로조회시_해당학기반환() {
+    // When - 이미 BaseRepositoryTest에서 currentTerm이 생성됨
+    Optional<AcademicTerm> result = academicTermRepository.findByYearAndTerm(2025, TermType.SPRING);
+
+    // Then
+    assertThat(result).isPresent();
+    assertAcademicTerm(result.get(), 2025, TermType.SPRING, true);
+  }
+
+  @Test
+  void 존재하지않는년도학기조회시_빈결과반환() {
+    // When - 존재하지 않는 학기로 조회
+    Optional<AcademicTerm> result = academicTermRepository.findByYearAndTerm(2023, TermType.WINTER);
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 새학기저장시_저장된학기반환() {
+    // Given
+    AcademicTerm term =
+        AcademicTerm.builder()
+            .academicYear(2025)
+            .semester(TermType.SUMMER)
+            .isCurrent(false)
+            .build();
+
+    // When
+    AcademicTerm savedTerm = academicTermRepository.save(term);
+
+    // Then
+    assertThat(savedTerm.getAcademicTermId()).isNotNull();
+    assertAcademicTerm(savedTerm, 2025, TermType.SUMMER, false);
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/repository/CourseRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/CourseRepositoryTest.java
@@ -1,0 +1,232 @@
+package edu.handong.csee.histudy.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.handong.csee.histudy.domain.Course;
+import edu.handong.csee.histudy.repository.jpa.JpaCourseRepository;
+import edu.handong.csee.histudy.support.BaseRepositoryTest;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CourseRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired private JpaCourseRepository courseRepository;
+
+  @Test
+  void 강의명키워드로검색시_대소문자무시하고일치강의반환() {
+    // Given
+    Course course1 =
+        Course.builder()
+            .name("Introduction to Programming")
+            .code("ECE101")
+            .professor("John Doe")
+            .academicTerm(currentTerm)
+            .build();
+
+    Course course2 =
+        Course.builder()
+            .name("Advanced Programming")
+            .code("ECE201")
+            .professor("Jane Smith")
+            .academicTerm(currentTerm)
+            .build();
+
+    Course course3 =
+        Course.builder()
+            .name("Database Systems")
+            .code("ECE301")
+            .professor("Bob Johnson")
+            .academicTerm(currentTerm)
+            .build();
+
+    persistAndFlush(course1);
+    persistAndFlush(course2);
+    persistAndFlush(course3);
+
+    // When
+    List<Course> results = courseRepository.findAllByNameContainingIgnoreCase("programming");
+
+    // Then - BaseRepositoryTest courses might also match, so check if our courses are included
+    assertThat(results).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(results)
+        .extracting("name")
+        .contains("Introduction to Programming", "Advanced Programming");
+  }
+
+  @Test
+  void 일치하지않는강의명검색시_빈결과반환() {
+    // Given
+    Course course =
+        Course.builder()
+            .name("Mathematics")
+            .code("MAT101")
+            .professor("Alice Brown")
+            .academicTerm(currentTerm)
+            .build();
+
+    persistAndFlush(course);
+
+    // When
+    List<Course> results = courseRepository.findAllByNameContainingIgnoreCase("physics");
+
+    // Then
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  void 현재학기강의조회시_현재학기강의목록반환() {
+    // Given
+    Course currentCourse =
+        Course.builder()
+            .name("Current Course")
+            .code("CUR101")
+            .professor("Current Prof")
+            .academicTerm(currentTerm)
+            .build();
+
+    Course pastCourse =
+        Course.builder()
+            .name("Past Course")
+            .code("PAS101")
+            .professor("Past Prof")
+            .academicTerm(pastTerm)
+            .build();
+
+    persistAndFlush(currentCourse);
+    persistAndFlush(pastCourse);
+
+    // When
+    List<Course> results = courseRepository.findAllByAcademicTermIsCurrentTrue();
+
+    // Then - BaseRepositoryTest에서 2개 + 추가로 1개 = 3개
+    assertThat(results).hasSize(3);
+    assertThat(results).anyMatch(course -> course.getName().equals("Current Course"));
+    assertThat(results).allMatch(course -> course.getAcademicTerm().getIsCurrent());
+  }
+
+  @Test
+  void 강의목록일괄저장시_모든강의저장성공() {
+    // Given
+    Course course1 =
+        Course.builder()
+            .name("Course 1")
+            .code("C001")
+            .professor("Prof 1")
+            .academicTerm(currentTerm)
+            .build();
+
+    Course course2 =
+        Course.builder()
+            .name("Course 2")
+            .code("C002")
+            .professor("Prof 2")
+            .academicTerm(currentTerm)
+            .build();
+
+    List<Course> courses = List.of(course1, course2);
+
+    // When
+    List<Course> savedCourses = courseRepository.saveAll(courses);
+
+    // Then
+    assertThat(savedCourses).hasSize(2);
+    assertThat(savedCourses).allMatch(course -> course.getCourseId() != null);
+  }
+
+  @Test
+  void 강의ID로존재확인시_존재여부반환() {
+    // Given
+    Course course =
+        Course.builder()
+            .name("Test Course")
+            .code("TEST101")
+            .professor("Test Prof")
+            .academicTerm(currentTerm)
+            .build();
+
+    Course savedCourse = persistAndFlush(course);
+
+    // When
+    boolean exists = courseRepository.existsById(savedCourse.getCourseId());
+    boolean notExists = courseRepository.existsById(999L);
+
+    // Then
+    assertThat(exists).isTrue();
+    assertThat(notExists).isFalse();
+  }
+
+  @Test
+  void 강의ID로삭제시_강의삭제성공() {
+    // Given
+    Course course =
+        Course.builder()
+            .name("To Delete Course")
+            .code("DEL101")
+            .professor("Delete Prof")
+            .academicTerm(currentTerm)
+            .build();
+
+    Course savedCourse = persistAndFlush(course);
+    Long courseId = savedCourse.getCourseId();
+
+    // When
+    courseRepository.deleteById(courseId);
+    flushAndClear();
+
+    // Then
+    Optional<Course> deletedCourse = courseRepository.findById(courseId);
+    assertThat(deletedCourse).isEmpty();
+  }
+
+  @Test
+  void 유효한강의ID로조회시_강의반환() {
+    // Given
+    Course course =
+        Course.builder()
+            .name("Find Course")
+            .code("FIND101")
+            .professor("Find Prof")
+            .academicTerm(currentTerm)
+            .build();
+
+    Course savedCourse = persistAndFlush(course);
+
+    // When
+    Optional<Course> result = courseRepository.findById(savedCourse.getCourseId());
+
+    // Then
+    assertThat(result).isPresent();
+    assertCourse(result.get(), "Find Course", "FIND101", "Find Prof");
+  }
+
+  @Test
+  void 존재하지않는강의ID로조회시_빈결과반환() {
+    // When
+    Optional<Course> result = courseRepository.findById(999L);
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 빈키워드로검색시_전체강의반환() {
+    // Given
+    Course course =
+        Course.builder()
+            .name("Test Course")
+            .code("TEST101")
+            .professor("Test Prof")
+            .academicTerm(currentTerm)
+            .build();
+
+    persistAndFlush(course);
+
+    // When
+    List<Course> results = courseRepository.findAllByNameContainingIgnoreCase("");
+
+    // Then - 빈 문자열은 모든 강의를 포함할 수 있음 (BaseRepositoryTest 2개 + 추가 1개)
+    assertThat(results).hasSize(3);
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyApplicantRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyApplicantRepositoryTest.java
@@ -1,0 +1,228 @@
+package edu.handong.csee.histudy.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyApplicantRepository;
+import edu.handong.csee.histudy.support.BaseRepositoryTest;
+import edu.handong.csee.histudy.support.TestDataFactory;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StudyApplicantRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired private JpaStudyApplicantRepository studyApplicantRepository;
+
+  @Test
+  void 사용자와학기로조회시_해당신청서반환() {
+    // Given
+    StudyApplicant applicant =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    persistAndFlush(applicant);
+
+    // When
+    Optional<StudyApplicant> result =
+        studyApplicantRepository.findByUserAndTerm(user1, currentTerm);
+
+    // Then
+    assertThat(result).isPresent();
+    assertThat(result.get().getUser()).isEqualTo(user1);
+    assertThat(result.get().getAcademicTerm()).isEqualTo(currentTerm);
+  }
+
+  @Test
+  void 존재하지않는사용자학기조회시_빈결과반환() {
+    // When
+    Optional<StudyApplicant> result =
+        studyApplicantRepository.findByUserAndTerm(user1, currentTerm);
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 미배정신청자조회시_배정되지않은신청자목록반환() {
+    // Given
+    StudyApplicant unassignedApplicant1 =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyApplicant unassignedApplicant2 =
+        TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(user1), List.of(course1));
+
+    // Create a study group and assign one applicant
+    StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(unassignedApplicant2));
+    unassignedApplicant2.markAsGrouped(studyGroup);
+
+    persistAndFlush(unassignedApplicant1);
+    persistAndFlush(unassignedApplicant2);
+    persistAndFlush(studyGroup);
+
+    // When
+    List<StudyApplicant> unassignedApplicants =
+        studyApplicantRepository.findUnassignedApplicants(currentTerm);
+
+    // Then
+    assertThat(unassignedApplicants).hasSize(1);
+    assertThat(unassignedApplicants.get(0).getUser()).isEqualTo(user1);
+    assertThat(unassignedApplicants.get(0).isNotMarkedAsGrouped()).isTrue();
+  }
+
+  @Test
+  void 배정신청자조회시_배정된신청자목록반환() {
+    // Given
+    StudyApplicant applicant1 =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyApplicant applicant2 =
+        TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(user1), List.of(course1));
+
+    StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(applicant1, applicant2));
+    applicant1.markAsGrouped(studyGroup);
+    applicant2.markAsGrouped(studyGroup);
+
+    persistAndFlush(applicant1);
+    persistAndFlush(applicant2);
+    persistAndFlush(studyGroup);
+
+    // When
+    List<StudyApplicant> assignedApplicants =
+        studyApplicantRepository.findAssignedApplicants(currentTerm);
+
+    // Then
+    assertThat(assignedApplicants).hasSize(2);
+    assertThat(assignedApplicants).allMatch(StudyApplicant::isMarkedAsGrouped);
+  }
+
+  @Test
+  void 특정학기신청자조회시_해당학기신청자목록반환() {
+    // Given
+    StudyApplicant currentApplicant =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyApplicant pastApplicant =
+        TestDataFactory.createStudyApplicant(pastTerm, user2, List.of(user1), List.of(course2));
+
+    persistAndFlush(currentApplicant);
+    persistAndFlush(pastApplicant);
+
+    // When
+    List<StudyApplicant> currentTermApplicants =
+        studyApplicantRepository.findAllByTerm(currentTerm);
+    List<StudyApplicant> pastTermApplicants = studyApplicantRepository.findAllByTerm(pastTerm);
+
+    // Then
+    assertThat(currentTermApplicants).hasSize(1);
+    assertThat(currentTermApplicants.get(0).getAcademicTerm()).isEqualTo(currentTerm);
+
+    assertThat(pastTermApplicants).hasSize(1);
+    assertThat(pastTermApplicants.get(0).getAcademicTerm()).isEqualTo(pastTerm);
+  }
+
+  @Test
+  void 스터디그룹별신청자조회시_해당그룹신청자목록반환() {
+    // Given
+    StudyApplicant applicant1 =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyApplicant applicant2 =
+        TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(user1), List.of(course1));
+    StudyApplicant applicant3 =
+        TestDataFactory.createStudyApplicant(currentTerm, user3, List.of(), List.of(course2));
+
+    StudyGroup studyGroup1 = StudyGroup.of(1, currentTerm, List.of(applicant1, applicant2));
+    StudyGroup studyGroup2 = StudyGroup.of(2, currentTerm, List.of(applicant3));
+
+    applicant1.markAsGrouped(studyGroup1);
+    applicant2.markAsGrouped(studyGroup1);
+    applicant3.markAsGrouped(studyGroup2);
+
+    persistAndFlush(applicant1);
+    persistAndFlush(applicant2);
+    persistAndFlush(applicant3);
+    persistAndFlush(studyGroup1);
+    persistAndFlush(studyGroup2);
+
+    // When
+    List<StudyApplicant> group1Applicants =
+        studyApplicantRepository.findAllByStudyGroup(studyGroup1);
+    List<StudyApplicant> group2Applicants =
+        studyApplicantRepository.findAllByStudyGroup(studyGroup2);
+
+    // Then
+    assertThat(group1Applicants).hasSize(2);
+    assertThat(group1Applicants).extracting("user").containsExactlyInAnyOrder(user1, user2);
+
+    assertThat(group2Applicants).hasSize(1);
+    assertThat(group2Applicants.get(0).getUser()).isEqualTo(user3);
+  }
+
+  @Test
+  void 새신청서저장시_저장된신청서반환() {
+    // Given
+    StudyApplicant applicant =
+        TestDataFactory.createStudyApplicant(
+            currentTerm, user1, List.of(user2, user3), List.of(course1, course2));
+
+    // When
+    StudyApplicant savedApplicant = studyApplicantRepository.save(applicant);
+
+    // Then
+    assertThat(savedApplicant.getStudyApplicantId()).isNotNull();
+    assertThat(savedApplicant.getUser()).isEqualTo(user1);
+    assertThat(savedApplicant.getAcademicTerm()).isEqualTo(currentTerm);
+    assertThat(savedApplicant.getPartnerRequests()).hasSize(2);
+    assertThat(savedApplicant.getPreferredCourses()).hasSize(2);
+  }
+
+  @Test
+  void 신청서삭제시_삭제성공() {
+    // Given
+    StudyApplicant applicant =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyApplicant savedApplicant = persistAndFlush(applicant);
+
+    // When
+    studyApplicantRepository.delete(savedApplicant);
+    flushAndClear();
+
+    // Then
+    Optional<StudyApplicant> deletedApplicant =
+        studyApplicantRepository.findByUserAndTerm(user1, currentTerm);
+    assertThat(deletedApplicant).isEmpty();
+  }
+
+  @Test
+  void 신청자없는학기조회시_모든조회빈결과반환() {
+    // Given - 다른 학기 신청자만 존재
+    StudyApplicant pastApplicant =
+        TestDataFactory.createStudyApplicant(pastTerm, user1, List.of(user2), List.of(course1));
+    persistAndFlush(pastApplicant);
+
+    // When
+    List<StudyApplicant> currentTermApplicants =
+        studyApplicantRepository.findAllByTerm(currentTerm);
+    List<StudyApplicant> unassignedApplicants =
+        studyApplicantRepository.findUnassignedApplicants(currentTerm);
+    List<StudyApplicant> assignedApplicants =
+        studyApplicantRepository.findAssignedApplicants(currentTerm);
+
+    // Then
+    assertThat(currentTermApplicants).isEmpty();
+    assertThat(unassignedApplicants).isEmpty();
+    assertThat(assignedApplicants).isEmpty();
+  }
+
+  @Test
+  void 복수친구요청포함신청서저장시_모든요청저장성공() {
+    // Given
+    StudyApplicant applicant =
+        TestDataFactory.createStudyApplicant(
+            currentTerm, user1, List.of(user2, user3), List.of(course1, course2));
+
+    // When
+    StudyApplicant savedApplicant = studyApplicantRepository.save(applicant);
+
+    // Then
+    assertThat(savedApplicant.getPartnerRequests()).hasSize(2);
+    assertThat(savedApplicant.getRequestedUsers()).containsExactlyInAnyOrder(user2, user3);
+    assertThat(savedApplicant.getPreferredCourses()).hasSize(2);
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyGroupRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyGroupRepositoryTest.java
@@ -1,0 +1,196 @@
+package edu.handong.csee.histudy.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyGroupRepository;
+import edu.handong.csee.histudy.support.BaseRepositoryTest;
+import edu.handong.csee.histudy.support.TestDataFactory;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+class StudyGroupRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired private JpaStudyGroupRepository studyGroupRepository;
+
+  @Test
+  void 태그와학기로조회시_해당스터디그룹반환() {
+    // Given
+    StudyApplicant applicant1 =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyApplicant applicant2 =
+        TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(user1), List.of(course1));
+
+    StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(applicant1, applicant2));
+    persistAndFlush(applicant1);
+    persistAndFlush(applicant2);
+    persistAndFlush(studyGroup);
+
+    // When
+    Optional<StudyGroup> result = studyGroupRepository.findByTagAndAcademicTerm(1, currentTerm);
+
+    // Then
+    assertThat(result).isPresent();
+    assertStudyGroup(result.get(), 1, currentTerm);
+  }
+
+  @Test
+  void 존재하지않는태그학기조회시_빈결과반환() {
+    // When
+    Optional<StudyGroup> result = studyGroupRepository.findByTagAndAcademicTerm(1, currentTerm);
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 최대태그번호조회시_가장큰태그번호반환() {
+    // Given
+    StudyGroup studyGroup1 = TestDataFactory.createStudyGroup(1, currentTerm);
+    StudyGroup studyGroup2 = TestDataFactory.createStudyGroup(3, currentTerm);
+    StudyGroup studyGroup3 = TestDataFactory.createStudyGroup(2, currentTerm);
+
+    persistAndFlush(studyGroup1);
+    persistAndFlush(studyGroup2);
+    persistAndFlush(studyGroup3);
+
+    // When
+    Optional<Integer> maxTag = studyGroupRepository.countMaxTag(currentTerm);
+
+    // Then
+    assertThat(maxTag).isPresent();
+    assertThat(maxTag.get()).isEqualTo(3);
+  }
+
+  @Test
+  void 그룹없는학기최대태그조회시_빈결과반환() {
+    // When
+    Optional<Integer> maxTag = studyGroupRepository.countMaxTag(currentTerm);
+
+    // Then
+    assertThat(maxTag).isEmpty();
+  }
+
+  @Test
+  void 학기별전체그룹조회시_태그순정렬된그룹목록반환() {
+    // Given
+    StudyGroup studyGroup3 = TestDataFactory.createStudyGroup(3, currentTerm);
+    StudyGroup studyGroup1 = TestDataFactory.createStudyGroup(1, currentTerm);
+    StudyGroup studyGroup2 = TestDataFactory.createStudyGroup(2, currentTerm);
+
+    persistAndFlush(studyGroup3);
+    persistAndFlush(studyGroup1);
+    persistAndFlush(studyGroup2);
+
+    // When
+    List<StudyGroup> studyGroups = studyGroupRepository.findAllByAcademicTerm(currentTerm);
+
+    // Then
+    assertThat(studyGroups).hasSize(3);
+    assertThat(studyGroups).extracting("tag").containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void 사용자와학기로그룹조회시_해당그룹반환() {
+    // Given
+    StudyApplicant applicant =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyGroup studyGroup = StudyGroup.of(1, currentTerm, List.of(applicant));
+
+    persistAndFlush(applicant);
+    persistAndFlush(studyGroup);
+
+    // When
+    Optional<StudyGroup> result = studyGroupRepository.findByUserAndTerm(user1, currentTerm);
+
+    // Then
+    assertThat(result).isPresent();
+    assertStudyGroup(result.get(), 1, currentTerm);
+  }
+
+  @Test
+  void 그룹없는사용자학기조회시_빈결과반환() {
+    // When
+    Optional<StudyGroup> result = studyGroupRepository.findByUserAndTerm(user1, currentTerm);
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @Transactional
+  void 빈그룹삭제실행시_빈그룹만삭제성공() {
+    // Given - 빈 그룹 생성
+    StudyGroup emptyGroup = TestDataFactory.createStudyGroup(1, currentTerm);
+    persistAndFlush(emptyGroup);
+
+    // 멤버가 있는 그룹 생성
+    StudyApplicant applicant =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(user2), List.of(course1));
+    StudyGroup groupWithMembers = StudyGroup.of(2, currentTerm, List.of(applicant));
+    persistAndFlush(applicant);
+    persistAndFlush(groupWithMembers);
+
+    // When
+    studyGroupRepository.deleteEmptyGroup(currentTerm);
+    flushAndClear();
+
+    // Then
+    List<StudyGroup> remainingGroups = studyGroupRepository.findAllByAcademicTerm(currentTerm);
+    assertThat(remainingGroups).hasSize(1);
+    assertThat(remainingGroups.get(0).getTag()).isEqualTo(2);
+  }
+
+  @Test
+  void 새스터디그룹저장시_저장된그룹반환() {
+    // Given
+    StudyGroup studyGroup = TestDataFactory.createStudyGroup(1, currentTerm);
+
+    // When
+    StudyGroup savedGroup = studyGroupRepository.save(studyGroup);
+
+    // Then
+    assertThat(savedGroup.getStudyGroupId()).isNotNull();
+    assertStudyGroup(savedGroup, 1, currentTerm);
+  }
+
+  @Test
+  void 스터디그룹삭제시_삭제성공() {
+    // Given
+    StudyGroup studyGroup = TestDataFactory.createStudyGroup(1, currentTerm);
+    StudyGroup savedGroup = persistAndFlush(studyGroup);
+
+    // When
+    studyGroupRepository.delete(savedGroup);
+    flushAndClear();
+
+    // Then
+    Optional<StudyGroup> deletedGroup =
+        studyGroupRepository.findByTagAndAcademicTerm(1, currentTerm);
+    assertThat(deletedGroup).isEmpty();
+  }
+
+  @Test
+  void 다른학기그룹조회시_학기별분리조회성공() {
+    // Given
+    StudyGroup currentGroup = TestDataFactory.createStudyGroup(1, currentTerm);
+    StudyGroup pastGroup = TestDataFactory.createStudyGroup(1, pastTerm);
+
+    persistAndFlush(currentGroup);
+    persistAndFlush(pastGroup);
+
+    // When
+    List<StudyGroup> currentGroups = studyGroupRepository.findAllByAcademicTerm(currentTerm);
+    List<StudyGroup> pastGroups = studyGroupRepository.findAllByAcademicTerm(pastTerm);
+
+    // Then
+    assertThat(currentGroups).hasSize(1);
+    assertThat(currentGroups.get(0).getAcademicTerm()).isEqualTo(currentTerm);
+
+    assertThat(pastGroups).hasSize(1);
+    assertThat(pastGroups.get(0).getAcademicTerm()).isEqualTo(pastTerm);
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/StudyReportRepositoryTest.java
@@ -1,0 +1,179 @@
+package edu.handong.csee.histudy.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.handong.csee.histudy.domain.*;
+import edu.handong.csee.histudy.repository.jpa.JpaStudyReportRepository;
+import edu.handong.csee.histudy.support.BaseRepositoryTest;
+import edu.handong.csee.histudy.support.TestDataFactory;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+class StudyReportRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired private JpaStudyReportRepository studyReportRepository;
+
+  private StudyGroup studyGroup1;
+  private StudyGroup studyGroup2;
+
+  @BeforeEach
+  void setUp() {
+    // Create study groups
+    StudyApplicant applicant1 =
+        TestDataFactory.createStudyApplicant(currentTerm, user1, List.of(), List.of(course1));
+    StudyApplicant applicant2 =
+        TestDataFactory.createStudyApplicant(currentTerm, user2, List.of(), List.of(course2));
+
+    studyGroup1 = StudyGroup.of(1, currentTerm, List.of(applicant1));
+    studyGroup2 = StudyGroup.of(2, currentTerm, List.of(applicant2));
+
+    persistAndFlush(applicant1);
+    persistAndFlush(applicant2);
+    persistAndFlush(studyGroup1);
+    persistAndFlush(studyGroup2);
+  }
+
+  @Test
+  @DirtiesContext
+  void 스터디그룹별보고서조회시_생성일자내림차순정렬반환() {
+    // Given
+    StudyReport report1 =
+        StudyReport.builder()
+            .title("First Report")
+            .content("Content 1")
+            .totalMinutes(60L)
+            .studyGroup(studyGroup1)
+            .participants(List.of(user1))
+            .images(List.of("image1.png"))
+            .courses(List.of(course1))
+            .build();
+
+    StudyReport report2 =
+        StudyReport.builder()
+            .title("Second Report")
+            .content("Content 2")
+            .totalMinutes(90L)
+            .studyGroup(studyGroup1)
+            .participants(List.of(user1))
+            .images(List.of("image2.png"))
+            .courses(List.of(course1))
+            .build();
+
+    StudyReport report3 =
+        StudyReport.builder()
+            .title("Different Group Report")
+            .content("Content 3")
+            .totalMinutes(120L)
+            .studyGroup(studyGroup2)
+            .participants(List.of(user2))
+            .images(List.of())
+            .courses(List.of(course2))
+            .build();
+
+    // Save reports with order: report1 first, then report2, then report3
+    persistAndFlush(report1);
+    persistAndFlush(report2);
+    persistAndFlush(report3);
+
+    // When
+    List<StudyReport> group1Reports =
+        studyReportRepository.findAllByStudyGroupOrderByCreatedDateDesc(studyGroup1);
+    List<StudyReport> group2Reports =
+        studyReportRepository.findAllByStudyGroupOrderByCreatedDateDesc(studyGroup2);
+
+    // Then
+    assertThat(group1Reports).hasSize(2);
+    // Since we can't guarantee order with identical timestamps, just verify group membership
+    assertThat(group1Reports)
+        .extracting("title")
+        .containsExactlyInAnyOrder("First Report", "Second Report");
+    assertThat(group1Reports).allMatch(report -> report.getStudyGroup().equals(studyGroup1));
+
+    assertThat(group2Reports).hasSize(1);
+    assertThat(group2Reports.get(0).getTitle()).isEqualTo("Different Group Report");
+  }
+
+  @Test
+  void 보고서없는그룹조회시_빈결과반환() {
+    // When
+    List<StudyReport> reports =
+        studyReportRepository.findAllByStudyGroupOrderByCreatedDateDesc(studyGroup1);
+
+    // Then
+    assertThat(reports).isEmpty();
+  }
+
+  @Test
+  void 새스터디보고서저장시_저장된보고서반환() {
+    // Given
+    StudyReport report = TestDataFactory.createStudyReport(studyGroup1, "Test Report Content");
+
+    // When
+    StudyReport savedReport = studyReportRepository.save(report);
+
+    // Then
+    assertThat(savedReport.getStudyReportId()).isNotNull();
+    assertThat(savedReport.getContent()).isEqualTo("Test Report Content");
+    assertThat(savedReport.getStudyGroup()).isEqualTo(studyGroup1);
+  }
+
+  @Test
+  void 스터디보고서삭제시_삭제성공() {
+    // Given
+    StudyReport report = TestDataFactory.createStudyReport(studyGroup1, "Test Report");
+    StudyReport savedReport = persistAndFlush(report);
+
+    // When
+    studyReportRepository.delete(savedReport);
+    flushAndClear();
+
+    // Then
+    List<StudyReport> reports =
+        studyReportRepository.findAllByStudyGroupOrderByCreatedDateDesc(studyGroup1);
+    assertThat(reports).isEmpty();
+  }
+
+  @Test
+  void 이미지포함보고서저장시_이미지경로포함저장성공() {
+    // Given
+    StudyReport report =
+        TestDataFactory.createStudyReport(studyGroup1, "Report with image", "/path/to/image.png");
+
+    // When
+    StudyReport savedReport = studyReportRepository.save(report);
+
+    // Then
+    assertThat(savedReport.getStudyReportId()).isNotNull();
+    assertThat(savedReport.getContent()).isEqualTo("Report with image");
+    assertThat(savedReport.getImages()).hasSize(1);
+    assertThat(savedReport.getStudyGroup()).isEqualTo(studyGroup1);
+  }
+
+  @Test
+  void 복수그룹보고서조회시_그룹별분리조회성공() {
+    // Given
+    StudyReport group1Report = TestDataFactory.createStudyReport(studyGroup1, "Group 1 Report");
+    StudyReport group2Report = TestDataFactory.createStudyReport(studyGroup2, "Group 2 Report");
+
+    persistAndFlush(group1Report);
+    persistAndFlush(group2Report);
+
+    // When
+    List<StudyReport> group1Reports =
+        studyReportRepository.findAllByStudyGroupOrderByCreatedDateDesc(studyGroup1);
+    List<StudyReport> group2Reports =
+        studyReportRepository.findAllByStudyGroupOrderByCreatedDateDesc(studyGroup2);
+
+    // Then
+    assertThat(group1Reports).hasSize(1);
+    assertThat(group1Reports.get(0).getContent()).isEqualTo("Group 1 Report");
+    assertThat(group1Reports.get(0).getStudyGroup()).isEqualTo(studyGroup1);
+
+    assertThat(group2Reports).hasSize(1);
+    assertThat(group2Reports.get(0).getContent()).isEqualTo("Group 2 Report");
+    assertThat(group2Reports.get(0).getStudyGroup()).isEqualTo(studyGroup2);
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/repository/UserRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/repository/UserRepositoryTest.java
@@ -1,0 +1,271 @@
+package edu.handong.csee.histudy.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.repository.jpa.JpaUserRepository;
+import edu.handong.csee.histudy.support.BaseRepositoryTest;
+import edu.handong.csee.histudy.support.TestDataFactory;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.persistence.PersistenceException;
+import org.springframework.data.domain.Sort;
+
+class UserRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired private JpaUserRepository userRepository;
+
+  @Test
+  void 유효한학번으로조회시_사용자반환() {
+    // Given
+    User user =
+        TestDataFactory.createUser(
+            "google-sub-901", "22500901", "test901@example.com", "Test User", Role.USER);
+    persistAndFlush(user);
+
+    // When
+    Optional<User> result = userRepository.findUserBySid("22500901");
+
+    // Then
+    assertThat(result).isPresent();
+    assertUser(result.get(), "google-sub-901", "22500901", "test901@example.com", "Test User");
+  }
+
+  @Test
+  void 존재하지않는학번으로조회시_빈결과반환() {
+    // When
+    Optional<User> result = userRepository.findUserBySid("99999999");
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 유효한이메일로조회시_사용자반환() {
+    // Given
+    User user =
+        TestDataFactory.createUser(
+            "google-sub-902", "22500902", "test902@example.com", "Test User", Role.USER);
+    persistAndFlush(user);
+
+    // When
+    Optional<User> result = userRepository.findUserByEmail("test902@example.com");
+
+    // Then
+    assertThat(result).isPresent();
+    assertUser(result.get(), "google-sub-902", "22500902", "test902@example.com", "Test User");
+  }
+
+  @Test
+  void 존재하지않는이메일로조회시_빈결과반환() {
+    // When
+    Optional<User> result = userRepository.findUserByEmail("nonexistent@example.com");
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 유효한SUB로조회시_사용자반환() {
+    // Given
+    User user =
+        TestDataFactory.createUser(
+            "google-sub-903", "22500903", "test903@example.com", "Test User", Role.USER);
+    persistAndFlush(user);
+
+    // When
+    Optional<User> result = userRepository.findUserBySub("google-sub-903");
+
+    // Then
+    assertThat(result).isPresent();
+    assertUser(result.get(), "google-sub-903", "22500903", "test903@example.com", "Test User");
+  }
+
+  @Test
+  void 키워드로검색시_일치하는사용자목록반환() {
+    // Given
+    User johnUser =
+        TestDataFactory.createUser("sub-john", "22500904", "john@example.com", "John Doe", Role.USER);
+    User janeUser =
+        TestDataFactory.createUser(
+            "sub-jane", "22500905", "jane@example.com", "Jane Smith", Role.USER);
+    User bobUser =
+        TestDataFactory.createUser("sub-bob", "22500906", "bob@test.com", "Bob Johnson", Role.USER);
+
+    persistAndFlush(johnUser);
+    persistAndFlush(janeUser);
+    persistAndFlush(bobUser);
+
+    // When - 이름으로 검색 (부분 매칭으로 "Doe"만 검색)
+    List<User> nameResults = userRepository.findUserByNameOrSidOrEmail("Doe");
+    // When - 학번으로 검색
+    List<User> sidResults = userRepository.findUserByNameOrSidOrEmail("22500905");
+    // When - 이메일로 검색
+    List<User> emailResults = userRepository.findUserByNameOrSidOrEmail("bob@test.com");
+
+    // Then
+    assertThat(nameResults).hasSize(1);
+    assertThat(nameResults.get(0).getName()).isEqualTo("John Doe");
+
+    assertThat(sidResults).hasSize(1);
+    assertThat(sidResults.get(0).getSid()).isEqualTo("22500905");
+
+    assertThat(emailResults).hasSize(1);
+    assertThat(emailResults.get(0).getEmail()).isEqualTo("bob@test.com");
+  }
+
+  @Test
+  void 일치하지않는키워드로검색시_빈결과반환() {
+    // Given
+    User user =
+        TestDataFactory.createUser("sub-test", "22500907", "test907@example.com", "Test User", Role.USER);
+    persistAndFlush(user);
+
+    // When
+    List<User> results = userRepository.findUserByNameOrSidOrEmail("nonexistent");
+
+    // Then
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  void 유효한ID로조회시_사용자반환() {
+    // Given
+    User user =
+        TestDataFactory.createUser("sub-id", "22500908", "test908@example.com", "Test User", Role.USER);
+    User savedUser = persistAndFlush(user);
+
+    // When
+    Optional<User> result = userRepository.findById(savedUser.getUserId());
+
+    // Then
+    assertThat(result).isPresent();
+    assertUser(result.get(), "sub-id", "22500908", "test908@example.com", "Test User");
+  }
+
+  @Test
+  void 이름순정렬조회시_정렬된사용자목록반환() {
+    // Given
+    User charlieUser =
+        TestDataFactory.createUser(
+            "sub-charlie", "22500909", "charlie@example.com", "Charlie", Role.USER);
+    User aliceUser =
+        TestDataFactory.createUser("sub-alice", "22500910", "alice@example.com", "Alice", Role.USER);
+    User bobUser =
+        TestDataFactory.createUser("sub-bobby", "22500911", "bobby@example.com", "Bobby", Role.USER);
+
+    persistAndFlush(charlieUser);
+    persistAndFlush(aliceUser);
+    persistAndFlush(bobUser);
+
+    // When - 이름으로 오름차순 정렬
+    List<User> results = userRepository.findAll(Sort.by("name"));
+
+    // Then
+    assertThat(results).hasSize(6); // 3 + base users from BaseRepositoryTest
+    // Check that our test users are sorted correctly
+    List<User> testUsers =
+        results.stream()
+            .filter(
+                u ->
+                    u.getName().equals("Alice")
+                        || u.getName().equals("Bobby")
+                        || u.getName().equals("Charlie"))
+            .toList();
+    assertThat(testUsers).hasSize(3);
+    assertThat(testUsers.get(0).getName()).isEqualTo("Alice");
+    assertThat(testUsers.get(1).getName()).isEqualTo("Bobby");
+    assertThat(testUsers.get(2).getName()).isEqualTo("Charlie");
+  }
+
+  @Test
+  void 새사용자저장시_저장된사용자반환() {
+    // Given
+    User user =
+        TestDataFactory.createUser(
+            "google-sub-new", "22500999", "new@example.com", "New User", Role.USER);
+
+    // When
+    User savedUser = userRepository.save(user);
+
+    // Then
+    assertThat(savedUser.getUserId()).isNotNull();
+    assertUser(savedUser, "google-sub-new", "22500999", "new@example.com", "New User");
+    assertThat(savedUser.getRole()).isEqualTo(Role.USER);
+  }
+
+  @Test
+  void 중복이메일저장시_예외발생() {
+    // Given
+    User user1 =
+        TestDataFactory.createUser("sub-dup1", "22500981", "same@example.com", "User 1", Role.USER);
+    User user2 =
+        TestDataFactory.createUser("sub-dup2", "22500982", "same@example.com", "User 2", Role.USER);
+
+    persistAndFlush(user1);
+
+    // When & Then
+    assertThatThrownBy(() -> persistAndFlush(user2))
+        .isInstanceOf(PersistenceException.class);
+  }
+
+  @Test
+  void 중복학번저장시_예외발생() {
+    // Given
+    User user1 =
+        TestDataFactory.createUser("sub-dup3", "22500983", "user1@example.com", "User 1", Role.USER);
+    User user2 =
+        TestDataFactory.createUser("sub-dup4", "22500983", "user2@example.com", "User 2", Role.USER);
+
+    persistAndFlush(user1);
+
+    // When & Then
+    assertThatThrownBy(() -> persistAndFlush(user2))
+        .isInstanceOf(PersistenceException.class);
+  }
+
+  @Test
+  void 중복SUB저장시_예외발생() {
+    // Given
+    User user1 =
+        TestDataFactory.createUser(
+            "same-sub", "22500984", "user3@example.com", "User 1", Role.USER);
+    User user2 =
+        TestDataFactory.createUser(
+            "same-sub", "22500985", "user4@example.com", "User 2", Role.USER);
+
+    persistAndFlush(user1);
+
+    // When & Then
+    assertThatThrownBy(() -> persistAndFlush(user2))
+        .isInstanceOf(PersistenceException.class);
+  }
+
+  @Test
+  void 다양한역할사용자저장시_모든역할저장성공() {
+    // Given
+    User admin =
+        TestDataFactory.createUser(
+            "admin-sub", "00000001", "admin@example.com", "Admin User", Role.ADMIN);
+    User member =
+        TestDataFactory.createUser(
+            "member-sub", "00000002", "member@example.com", "Member User", Role.MEMBER);
+    User regularUser =
+        TestDataFactory.createUser(
+            "user-sub", "00000003", "user@example.com", "Regular User", Role.USER);
+
+    // When
+    User savedAdmin = userRepository.save(admin);
+    User savedMember = userRepository.save(member);
+    User savedUser = userRepository.save(regularUser);
+
+    // Then
+    assertThat(savedAdmin.getRole()).isEqualTo(Role.ADMIN);
+    assertThat(savedMember.getRole()).isEqualTo(Role.MEMBER);
+    assertThat(savedUser.getRole()).isEqualTo(Role.USER);
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/CourseServiceTest.java
@@ -6,6 +6,7 @@ import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.service.repository.fake.*;
+import edu.handong.csee.histudy.support.TestDataFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,29 +41,27 @@ public class CourseServiceTest {
             studyGroupRepository,
             studyApplicantRepository);
 
-    AcademicTerm term =
-        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+    AcademicTerm term = TestDataFactory.createCurrentTerm();
     academicTermRepository.save(term);
 
-    User student1 =
-        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
-
-    User student2 =
-        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+    User student1 = TestDataFactory.createUser("1", "22500101", "user1@test.com", "Foo", Role.USER);
+    User student2 = TestDataFactory.createUser("2", "22500102", "user2@test.com", "Bar", Role.USER);
 
     userRepository.save(student1);
     userRepository.save(student2);
 
-    Course course1 = new Course("Introduction to Algorithms", "ECE00101", "John Doe", term);
-    Course course2 = new Course("Introduction to Data Structures", "ECE00102", "John Doe", term);
+    Course course1 =
+        TestDataFactory.createCourse("Introduction to Algorithms", "ECE00101", "John Doe", term);
+    Course course2 =
+        TestDataFactory.createCourse(
+            "Introduction to Data Structures", "ECE00102", "John Doe", term);
 
     courseRepository.saveAll(List.of(course1, course2));
 
     StudyApplicant studyApplicant1 =
-        StudyApplicant.of(term, student1, List.of(student2), List.of(course1));
-
+        TestDataFactory.createStudyApplicant(term, student1, List.of(student2), List.of(course1));
     StudyApplicant studyApplicant2 =
-        StudyApplicant.of(term, student2, List.of(student1), List.of(course2));
+        TestDataFactory.createStudyApplicant(term, student2, List.of(student1), List.of(course2));
 
     studyApplicantRepository.save(studyApplicant1);
     studyApplicantRepository.save(studyApplicant2);
@@ -72,7 +71,7 @@ public class CourseServiceTest {
   }
 
   @Test
-  void 강의목록_검색_전체() {
+  void 호출시_전체강의목록반환() {
     // When
     List<CourseDto.CourseInfo> courses = courseService.getCurrentCourses();
 
@@ -81,7 +80,7 @@ public class CourseServiceTest {
   }
 
   @Test
-  void 강의목록_검색_키워드() {
+  void 키워드제공시_일치하는강의반환() {
     // When
     String keyword1 = "algo";
     String keyword2 = "intro";
@@ -95,7 +94,7 @@ public class CourseServiceTest {
   }
 
   @Test
-  void 스터디그룹_선택과목_목록_조회() {
+  void 사용자이메일시_팀강의목록반환() {
     // When
     List<CourseDto.CourseInfo> res = courseService.getTeamCourses("user1@test.com");
 
@@ -104,7 +103,7 @@ public class CourseServiceTest {
   }
 
   @Test
-  void 강의목록_업로드() throws IOException {
+  void CSV파일제공시_강의저장() throws IOException {
     // Given
     String content =
         """
@@ -123,7 +122,7 @@ public class CourseServiceTest {
   }
 
   @Test
-  void CSV파일로_강의목록_읽기_성공() throws IOException {
+  void 유효한CSV파일시_강의저장성공() throws IOException {
     // Given
     String csvContent =
         """
@@ -151,7 +150,7 @@ public class CourseServiceTest {
   }
 
   @Test
-  void CSV파일로_새로운_학기_생성() throws IOException {
+  void 새학기데이터시_학기생성() throws IOException {
     // Given
     String csvContent =
         """
@@ -175,7 +174,7 @@ public class CourseServiceTest {
   }
 
   @Test
-  void CSV파일_읽기_중_IOException_발생() {
+  void IO예외발생시_예외전파() {
     // Given
     MockMultipartFile file =
         new MockMultipartFile("invalid.csv", "invalid.csv", "text/csv", (byte[]) null) {

--- a/src/test/java/edu/handong/csee/histudy/service/JwtServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/JwtServiceTest.java
@@ -22,13 +22,14 @@ public class JwtServiceTest {
 
   @BeforeEach
   void init() {
-    String secret = Base64.getEncoder().encodeToString("test-secret-key-for-jwt-service-test".getBytes());
+    String secret =
+        Base64.getEncoder().encodeToString("test-secret-key-for-jwt-service-test".getBytes());
     jwtProperties = new JwtProperties(secret, "HIStudy", "3600", "86400");
     jwtService = new JwtService(jwtProperties);
   }
 
   @Test
-  void JWT토큰_발급_성공() {
+  void 유저정보제공시_토큰쌍발급() {
     // Given
     String email = "test@example.com";
     String name = "Test User";
@@ -44,7 +45,7 @@ public class JwtServiceTest {
   }
 
   @Test
-  void JWT토큰_검증_성공() {
+  void 유효토큰시_클레임반환() {
     // Given
     String email = "test@example.com";
     String name = "Test User";
@@ -62,17 +63,16 @@ public class JwtServiceTest {
   }
 
   @Test
-  void 잘못된JWT토큰_검증_실패() {
+  void 잘못된토큰시_예외발생() {
     // Given
     String invalidToken = "invalid.jwt.token";
 
     // When & Then
-    assertThatThrownBy(() -> jwtService.validate(invalidToken))
-        .isInstanceOf(JwtException.class);
+    assertThatThrownBy(() -> jwtService.validate(invalidToken)).isInstanceOf(JwtException.class);
   }
 
   @Test
-  void Bearer토큰_추출_성공() {
+  void Bearer헤더시_토큰추출() {
     // Given
     String token = "sample-jwt-token";
     String bearerToken = "Bearer " + token;
@@ -86,7 +86,7 @@ public class JwtServiceTest {
   }
 
   @Test
-  void Bearer토큰_추출_잘못된형식_실패() {
+  void 잘못된헤더형식시_예외발생() {
     // Given
     Optional<String> headerOr = Optional.of("InvalidFormat token");
 
@@ -96,7 +96,7 @@ public class JwtServiceTest {
   }
 
   @Test
-  void Bearer토큰_추출_헤더없음_실패() {
+  void 헤더없을시_예외발생() {
     // Given
     Optional<String> headerOr = Optional.empty();
 
@@ -106,7 +106,7 @@ public class JwtServiceTest {
   }
 
   @Test
-  void Claims로부터_토큰발급_ACCESS_TOKEN() {
+  void 클레임으로_액세스토큰발급() {
     // Given
     String email = "test@example.com";
     String name = "Test User";
@@ -126,7 +126,7 @@ public class JwtServiceTest {
   }
 
   @Test
-  void Claims로부터_토큰발급_REFRESH_TOKEN() {
+  void 클레임으로_리프레시토큰발급() {
     // Given
     String email = "test@example.com";
     String name = "Test User";
@@ -146,7 +146,7 @@ public class JwtServiceTest {
   }
 
   @Test
-  void ADMIN역할_토큰발급_검증() {
+  void 관리자역할시_토큰발급() {
     // Given
     String email = "admin@example.com";
     String name = "Admin User";
@@ -161,7 +161,7 @@ public class JwtServiceTest {
   }
 
   @Test
-  void MEMBER역할_토큰발급_검증() {
+  void 멤버역할시_토큰발급() {
     // Given
     String email = "member@example.com";
     String name = "Member User";

--- a/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
@@ -6,6 +6,7 @@ import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.*;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.service.repository.fake.*;
+import edu.handong.csee.histudy.support.TestDataFactory;
 import edu.handong.csee.histudy.util.ImagePathMapper;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,33 +52,24 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 그룹원정보확인_학번은_마스킹되어있어야함() {
+  void 그룹원조회시_학번마스킹() {
     // Given
-    AcademicTerm term =
-        AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+    AcademicTerm term = TestDataFactory.createCurrentTerm();
     academicTermRepository.save(term);
 
-    User student1 =
-        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
-
-    User student2 =
-        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
-
-    User student3 =
-        User.builder().sub("3").sid("22500103").email("user3@test.com").name("baz").build();
+    User student1 = TestDataFactory.createUser("1", "22500101", "user1@test.com", "Foo", Role.USER);
+    User student2 = TestDataFactory.createUser("2", "22500102", "user2@test.com", "Bar", Role.USER);
+    User student3 = TestDataFactory.createUser("3", "22500103", "user3@test.com", "baz", Role.USER);
 
     userRepository.save(student1);
     userRepository.save(student2);
     userRepository.save(student3);
 
-    Course course = new Course("Introduction to Test", "ECE00103", "John", term);
+    Course course = TestDataFactory.createCourse("Introduction to Test", "ECE00103", "John", term);
     courseRepository.saveAll(List.of(course));
 
-    StudyApplicant studyApplicant1 =
-        StudyApplicant.of(term, student1, List.of(student2), List.of(course));
-
-    StudyApplicant studyApplicant2 =
-        StudyApplicant.of(term, student2, List.of(student1), List.of(course));
+    StudyApplicant studyApplicant1 = TestDataFactory.createStudyApplicant(term, student1, List.of(student2), List.of(course));
+    StudyApplicant studyApplicant2 = TestDataFactory.createStudyApplicant(term, student2, List.of(student1), List.of(course));
 
     studyApplicantRepository.save(studyApplicant1);
     studyApplicantRepository.save(studyApplicant2);
@@ -95,7 +87,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 그룹매칭_친구들끼리() {
+  void 친구선호시_그룹매칭() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -134,7 +126,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 그룹매칭_과목우선() {
+  void 과목동일시_그룹매칭() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -175,7 +167,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 그룹매칭_친구들과_과목같이() {
+  void 친구와과목모두일치시_그룹매칭() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -218,7 +210,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 팀목록조회_관리자용() {
+  void 관리자요청시_전체팀목록반환() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -254,7 +246,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 팀삭제_성공() {
+  void 유효한팀ID시_삭제성공() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -285,7 +277,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 팀삭제_존재하지않는팀() {
+  void 존재하지않는팀ID시_0반환() {
     // Given
     TeamIdDto dto = new TeamIdDto();
     dto.setGroupId(999L);
@@ -298,7 +290,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 팀보고서조회() {
+  void 팀존재시_보고서목록반환() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -341,7 +333,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 전체팀랭킹조회() {
+  void 전체팀조회시_랭킹순반환() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -402,7 +394,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 그룹매칭_빈목록() {
+  void 빈신청목록시_오류없이처리() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
@@ -413,7 +405,7 @@ public class TeamServiceTest {
   }
 
   @Test
-  void 그룹매칭_5명이상_그룹분할() {
+  void 다섯명이상시_그룹분할() {
     // Given
     AcademicTerm term =
         AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();

--- a/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.*;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.service.repository.fake.*;
+import edu.handong.csee.histudy.support.TestDataFactory;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,13 +45,10 @@ public class UserServiceTest {
   }
 
   @Test
-  void 학생명단_검색_키워드없는경우_전부표시() {
+  void 키워드없을시_전체학생조회() {
     // Given
-    User student1 =
-        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
-
-    User student2 =
-        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+    User student1 = TestDataFactory.createUser("1", "22500101", "user1@test.com", "Foo", Role.USER);
+    User student2 = TestDataFactory.createUser("2", "22500102", "user2@test.com", "Bar", Role.USER);
 
     userRepository.save(student1);
     userRepository.save(student2);
@@ -63,7 +61,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 학생명단_검색_키워드있는경우_해당하는학생만표시() {
+  void 키워드제공시_매칭학생조회() {
     // Given
     User student1 =
         User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
@@ -82,19 +80,16 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_최초신청한경우_요청대기중() {
+  void 최초신청시_요청대기중() {
     // Given
-    AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
+    AcademicTerm term = TestDataFactory.createCurrentTerm();
     academicTermRepository.save(term);
 
-    Course course = new Course("Introduction to Test", "ECE2025", "Bar", term);
+    Course course = TestDataFactory.createCourse("Introduction to Test", "ECE2025", "Bar", term);
     courseRepository.saveAll(List.of(course));
 
-    User student1 =
-        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
-
-    User student2 =
-        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+    User student1 = TestDataFactory.createUser("1", "22500101", "user1@test.com", "Foo", Role.USER);
+    User student2 = TestDataFactory.createUser("2", "22500102", "user2@test.com", "Bar", Role.USER);
 
     userRepository.save(student1);
     User bar = userRepository.save(student2);
@@ -110,7 +105,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_같이하고싶은멤버로_추가된요청이있는경우_서로ACCEPTED() {
+  void 상호요청시_서로승인() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -143,7 +138,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_신청하지않은경우_신청정보_없음() {
+  void 신청안했을시_정보없음() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -161,7 +156,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_신청한경우_신청정보_있음() {
+  void 신청했을시_정보있음() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -188,7 +183,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 사용자회원가입_성공() {
+  void 새사용자정보시_회원가입성공() {
     // Given
     UserForm userForm = new UserForm("google-sub-123", "New User", "newuser@test.com", "22500103");
 
@@ -204,14 +199,15 @@ public class UserServiceTest {
   }
 
   @Test
-  void 사용자회원가입_이미존재하는사용자() {
+  void 이미존재하는사용자시_예외발생() {
     // Given
-    User existingUser = User.builder()
-        .sub("google-sub-123")
-        .sid("22500103")
-        .email("existing@test.com")
-        .name("Existing User")
-        .build();
+    User existingUser =
+        User.builder()
+            .sub("google-sub-123")
+            .sid("22500103")
+            .email("existing@test.com")
+            .name("Existing User")
+            .build();
     userRepository.save(existingUser);
 
     UserForm userForm = new UserForm("google-sub-123", "New User", "newuser@test.com", "22500104");
@@ -222,14 +218,15 @@ public class UserServiceTest {
   }
 
   @Test
-  void 사용자정보조회_sub로() {
+  void sub제공시_사용자정보반환() {
     // Given
-    User user = User.builder()
-        .sub("google-sub-123")
-        .sid("22500103")
-        .email("user@test.com")
-        .name("Test User")
-        .build();
+    User user =
+        User.builder()
+            .sub("google-sub-123")
+            .sid("22500103")
+            .email("user@test.com")
+            .name("Test User")
+            .build();
     userRepository.save(user);
 
     // When
@@ -241,29 +238,30 @@ public class UserServiceTest {
   }
 
   @Test
-  void 사용자정보조회_sub없음() {
+  void sub없을시_예외발생() {
     // When & Then
     assertThatThrownBy(() -> userService.getUser(Optional.empty()))
         .isInstanceOf(MissingSubException.class);
   }
 
   @Test
-  void 사용자정보조회_존재하지않는sub() {
+  void 존재하지않는sub시_예외발생() {
     // When & Then
     assertThatThrownBy(() -> userService.getUser(Optional.of("nonexistent-sub")))
         .isInstanceOf(UserNotFoundException.class);
   }
 
   @Test
-  void 내정보조회_성공() {
+  void 이메일제공시_내정보반환() {
     // Given
-    User user = User.builder()
-        .sub("1")
-        .sid("22500101")
-        .email("user1@test.com")
-        .name("Foo")
-        .role(Role.USER)
-        .build();
+    User user =
+        User.builder()
+            .sub("1")
+            .sid("22500101")
+            .email("user1@test.com")
+            .name("Foo")
+            .role(Role.USER)
+            .build();
     userRepository.save(user);
 
     // When
@@ -275,14 +273,14 @@ public class UserServiceTest {
   }
 
   @Test
-  void 내정보조회_이메일없음() {
+  void 이메일없을시_예외발생() {
     // When & Then
     assertThatThrownBy(() -> userService.getUserMe(Optional.empty()))
         .isInstanceOf(MissingEmailException.class);
   }
 
   @Test
-  void 스터디그룹_신청_ApplyForm사용() {
+  void 신청폼제공시_신청성공() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -290,16 +288,16 @@ public class UserServiceTest {
     Course course = new Course("Introduction to Test", "ECE2025", "Bar", term);
     courseRepository.saveAll(List.of(course));
 
-    User student1 = User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
-    User student2 = User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+    User student1 =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+    User student2 =
+        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
 
     userRepository.save(student1);
     userRepository.save(student2);
 
-    ApplyForm form = ApplyForm.builder()
-        .friendIds(List.of("22500102"))
-        .courseIds(List.of(1L))
-        .build();
+    ApplyForm form =
+        ApplyForm.builder().friendIds(List.of("22500102")).courseIds(List.of(1L)).build();
 
     // When
     ApplyFormDto result = userService.apply(form, "user1@test.com");
@@ -310,7 +308,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_신청_존재하지않는사용자() {
+  void 존재하지않는사용자신청시_예외발생() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -321,9 +319,10 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_신청_현재학기없음() {
+  void 현재학기없이신청시_예외발생() {
     // Given
-    User student = User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+    User student =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
     userRepository.save(student);
 
     // When & Then
@@ -332,12 +331,13 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_신청_존재하지않는친구() {
+  void 존재하지않는친구신청시_예외발생() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
 
-    User student = User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+    User student =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
     userRepository.save(student);
 
     // When & Then
@@ -346,12 +346,13 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_신청_존재하지않는과목() {
+  void 존재하지않는과목신청시_예외발생() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
 
-    User student = User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+    User student =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
     userRepository.save(student);
 
     // When & Then
@@ -360,18 +361,17 @@ public class UserServiceTest {
   }
 
   @Test
-  void 스터디그룹_신청_ApplyForm_존재하지않는친구() {
+  void 신청폼에존재하지않는친구시_예외발생() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
 
-    User student = User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+    User student =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
     userRepository.save(student);
 
-    ApplyForm form = ApplyForm.builder()
-        .friendIds(List.of("nonexistent"))
-        .courseIds(List.of())
-        .build();
+    ApplyForm form =
+        ApplyForm.builder().friendIds(List.of("nonexistent")).courseIds(List.of()).build();
 
     // When & Then
     assertThatThrownBy(() -> userService.apply(form, "user1@test.com"))
@@ -379,7 +379,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 사용자신청서삭제_성공() {
+  void 신청서있을시_삭제성공() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -387,7 +387,8 @@ public class UserServiceTest {
     Course course = new Course("Introduction to Test", "ECE2025", "Bar", term);
     courseRepository.saveAll(List.of(course));
 
-    User student = User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+    User student =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
     userRepository.save(student);
 
     userService.apply(List.of(), List.of(1L), "user1@test.com");
@@ -401,7 +402,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 사용자신청서삭제_존재하지않는사용자() {
+  void 존재하지않는사용자삭제시_예외발생() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -412,7 +413,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 신청한사용자목록조회() {
+  void 신청한사용자있을시_목록반환() {
     // Given
     AcademicTerm term = new AcademicTerm(1L, 2025, TermType.SPRING, true);
     academicTermRepository.save(term);
@@ -420,8 +421,10 @@ public class UserServiceTest {
     Course course = new Course("Introduction to Test", "ECE2025", "Bar", term);
     courseRepository.saveAll(List.of(course));
 
-    User student1 = User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
-    User student2 = User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
+    User student1 =
+        User.builder().sub("1").sid("22500101").email("user1@test.com").name("Foo").build();
+    User student2 =
+        User.builder().sub("2").sid("22500102").email("user2@test.com").name("Bar").build();
 
     userRepository.save(student1);
     userRepository.save(student2);
@@ -437,7 +440,7 @@ public class UserServiceTest {
   }
 
   @Test
-  void 신청한사용자목록조회_현재학기없음() {
+  void 현재학기없이신청자조회시_예외발생() {
     // When & Then
     assertThatThrownBy(() -> userService.getAppliedUsers())
         .isInstanceOf(NoCurrentTermFoundException.class);

--- a/src/test/java/edu/handong/csee/histudy/support/BaseRepositoryTest.java
+++ b/src/test/java/edu/handong/csee/histudy/support/BaseRepositoryTest.java
@@ -1,0 +1,83 @@
+package edu.handong.csee.histudy.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.handong.csee.histudy.domain.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class BaseRepositoryTest {
+
+    @Autowired
+    protected TestEntityManager entityManager;
+
+    protected AcademicTerm currentTerm;
+    protected AcademicTerm pastTerm;
+    protected User user1, user2, user3;
+    protected Course course1, course2;
+
+    @BeforeEach
+    void baseSetup() {
+        setupBaseEntities();
+        persistBaseEntities();
+    }
+
+    private void setupBaseEntities() {
+        currentTerm = TestDataFactory.createCurrentTerm();
+        pastTerm = TestDataFactory.createPastTerm();
+        user1 = TestDataFactory.createUser("1");
+        user2 = TestDataFactory.createUser("2");
+        user3 = TestDataFactory.createUser("3");
+        course1 = TestDataFactory.createCourse("Introduction to Programming", "ECE101", currentTerm);
+        course2 = TestDataFactory.createCourse("Database Systems", "ECE201", currentTerm);
+    }
+
+    private void persistBaseEntities() {
+        entityManager.persistAndFlush(currentTerm);
+        entityManager.persistAndFlush(pastTerm);
+        entityManager.persistAndFlush(user1);
+        entityManager.persistAndFlush(user2);
+        entityManager.persistAndFlush(user3);
+        entityManager.persistAndFlush(course1);
+        entityManager.persistAndFlush(course2);
+    }
+
+    protected <T> T persistAndFlush(T entity) {
+        return entityManager.persistAndFlush(entity);
+    }
+
+    protected void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    // 공통 검증 헬퍼 메서드들
+    protected void assertAcademicTerm(AcademicTerm actual, int expectedYear, TermType expectedSemester, boolean expectedCurrent) {
+        assertThat(actual.getAcademicYear()).isEqualTo(expectedYear);
+        assertThat(actual.getSemester()).isEqualTo(expectedSemester);
+        assertThat(actual.getIsCurrent()).isEqualTo(expectedCurrent);
+    }
+
+    protected void assertUser(User actual, String expectedSub, String expectedSid, String expectedEmail, String expectedName) {
+        assertThat(actual.getSub()).isEqualTo(expectedSub);
+        assertThat(actual.getSid()).isEqualTo(expectedSid);
+        assertThat(actual.getEmail()).isEqualTo(expectedEmail);
+        assertThat(actual.getName()).isEqualTo(expectedName);
+    }
+
+    protected void assertCourse(Course actual, String expectedName, String expectedCode, String expectedProfessor) {
+        assertThat(actual.getName()).isEqualTo(expectedName);
+        assertThat(actual.getCode()).isEqualTo(expectedCode);
+        assertThat(actual.getProfessor()).isEqualTo(expectedProfessor);
+    }
+
+    protected void assertStudyGroup(StudyGroup actual, int expectedTag, AcademicTerm expectedTerm) {
+        assertThat(actual.getTag()).isEqualTo(expectedTag);
+        assertThat(actual.getAcademicTerm()).isEqualTo(expectedTerm);
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/support/TestDataFactory.java
+++ b/src/test/java/edu/handong/csee/histudy/support/TestDataFactory.java
@@ -1,0 +1,93 @@
+package edu.handong.csee.histudy.support;
+
+import edu.handong.csee.histudy.domain.*;
+import java.util.List;
+
+public class TestDataFactory {
+
+  public static AcademicTerm createCurrentTerm() {
+    return AcademicTerm.builder()
+        .academicYear(2025)
+        .semester(TermType.SPRING)
+        .isCurrent(true)
+        .build();
+  }
+
+  public static AcademicTerm createPastTerm() {
+    return AcademicTerm.builder()
+        .academicYear(2024)
+        .semester(TermType.FALL)
+        .isCurrent(false)
+        .build();
+  }
+
+  public static AcademicTerm createAcademicTerm(int year, TermType semester, boolean isCurrent) {
+    return AcademicTerm.builder()
+        .academicYear(year)
+        .semester(semester)
+        .isCurrent(isCurrent)
+        .build();
+  }
+
+  public static User createUser(String suffix) {
+    return User.builder()
+        .sub("sub-" + suffix)
+        .sid("2250010" + suffix)
+        .email("user" + suffix + "@test.com")
+        .name("User " + suffix)
+        .role(Role.USER)
+        .build();
+  }
+
+  public static User createUser(String sub, String sid, String email, String name, Role role) {
+    return User.builder().sub(sub).sid(sid).email(email).name(name).role(role).build();
+  }
+
+  public static Course createCourse(String name, String code, AcademicTerm term) {
+    return Course.builder()
+        .name(name)
+        .code(code)
+        .professor("Prof " + code)
+        .academicTerm(term)
+        .build();
+  }
+
+  public static Course createCourse(String name, String code, String professor, AcademicTerm term) {
+    return Course.builder().name(name).code(code).professor(professor).academicTerm(term).build();
+  }
+
+  public static StudyGroup createStudyGroup(int tag, AcademicTerm term) {
+    // Create a simple study group without members for basic testing
+    return StudyGroup.of(tag, term, List.of());
+  }
+
+  public static StudyApplicant createStudyApplicant(
+      AcademicTerm term, User user, List<User> preferredFriends, List<Course> preferredCourses) {
+    return StudyApplicant.of(term, user, preferredFriends, preferredCourses);
+  }
+
+  public static StudyReport createStudyReport(StudyGroup studyGroup, String content) {
+    return StudyReport.builder()
+        .title("Test Report")
+        .studyGroup(studyGroup)
+        .content(content)
+        .totalMinutes(60L)
+        .participants(List.of())
+        .images(List.of())
+        .courses(List.of())
+        .build();
+  }
+
+  public static StudyReport createStudyReport(
+      StudyGroup studyGroup, String content, String imagePath) {
+    return StudyReport.builder()
+        .title("Test Report")
+        .studyGroup(studyGroup)
+        .content(content)
+        .totalMinutes(60L)
+        .participants(List.of())
+        .images(List.of(imagePath))
+        .courses(List.of())
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

컨트롤러 레이어에 대한 포괄적인 단위 테스트를 추가했습니다.

### 추가된 테스트

- **AdminControllerTest** (10개 테스트)
  - 관리자 권한 검증 및 그룹 관리 API 테스트
- **ApplyFormControllerTest** (4개 테스트)  
  - 스터디 신청 폼 V1/V2 API 테스트
- **AuthControllerTest** (4개 테스트)
  - 로그인 및 토큰 재발급 API 테스트
- **CourseControllerTest** (8개 테스트)
  - 강의 업로드, 조회, 삭제 API 테스트
- **PublicControllerTest** (1개 테스트)
  - 공개 그룹 목록 조회 API 테스트
- **TeamControllerTest** (13개 테스트)
  - 그룹 보고서 관리 및 이미지 업로드 API 테스트
- **UserControllerTest** (10개 테스트)
  - 사용자 정보 조회 및 검색 API 테스트

### 기술적 구현

- `@WebMvcTest`와 `MockMvc`를 활용한 웹 레이어 단위 테스트
- `MockMvcBuilders.standaloneSetup()`으로 JWT Claims 바인딩 이슈 해결
- 서비스 레이어 `@MockBean` 처리로 격리된 테스트 환경 구성
- 권한 기반 접근 제어 및 예외 상황 테스트 포함
- WHEN_THEN 형식의 한국어 테스트 메소드명으로 가독성 향상

### 테스트 결과

- **총 50개 테스트 케이스**
- **100% 성공률 달성**
- 모든 컨트롤러 엔드포인트에 대한 포괄적 커버리지 확보